### PR TITLE
Fix image drop issue in wine details page (WineView)

### DIFF
--- a/public/js/views/winedetails.js
+++ b/public/js/views/winedetails.js
@@ -10,10 +10,11 @@ window.WineView = Backbone.View.extend({
     },
 
     events: {
-        "change"        : "change",
-        "click .save"   : "beforeSave",
-        "click .delete" : "deleteWine",
-        "drop #picture" : "dropHandler"
+        "change"            : "change",
+        "click .save"       : "beforeSave",
+        "click .delete"     : "deleteWine",
+        "drop #picture"     : "dropHandler",
+        "dragover #picture" : "dragoverHandler"
     },
 
     change: function (event) {
@@ -84,6 +85,10 @@ window.WineView = Backbone.View.extend({
             $('#picture').attr('src', reader.result);
         };
         reader.readAsDataURL(this.pictureFile);
+    },
+
+    dragoverHandler: function(event) {
+        event.preventDefault();
     }
 
 });


### PR DESCRIPTION
Related to issue #3 (well, kind of, anyway). Fixes and issue where the picture drop isn't handled correctly on Chrome 24.x since at least 3 Jan 2013.

This is not a temporary patch. AFAIK the new Chrome behavior is following spec.

This is just a drive-by spike, do as you please.
